### PR TITLE
Make module build with latest kernel (5.6) and gcc (9.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,14 +67,14 @@ LINUX:
 
 ifeq ($(OSABL),YES)
 	@cp os/linux/Makefile.6.util $(RT28xx_DIR)/os/linux/Makefile
-	$(MAKE) -C $(LINUX_SRC) SUBDIRS=$(RT28xx_DIR)/os/linux modules
+	$(MAKE) -C $(LINUX_SRC) M=$(RT28xx_DIR)/os/linux modules
 endif
 	@cp os/linux/Makefile.6 $(RT28xx_DIR)/os/linux/Makefile
-	$(MAKE) -C $(LINUX_SRC) SUBDIRS=$(RT28xx_DIR)/os/linux modules
+	$(MAKE) -C $(LINUX_SRC) M=$(RT28xx_DIR)/os/linux modules
 
 ifeq ($(OSABL),YES)
 	@cp os/linux/Makefile.6.netif $(RT28xx_DIR)/os/linux/Makefile
-	$(MAKE) -C $(LINUX_SRC) SUBDIRS=$(RT28xx_DIR)/os/linux modules
+	$(MAKE) -C $(LINUX_SRC) M=$(RT28xx_DIR)/os/linux modules
 endif
 
 release: build_tools
@@ -115,23 +115,23 @@ install:
 
 libwapi:
 	cp os/linux/Makefile.libwapi.6 $(RT28xx_DIR)/os/linux/Makefile
-	$(MAKE) -C $(LINUX_SRC) SUBDIRS=$(RT28xx_DIR)/os/linux modules
+	$(MAKE) -C $(LINUX_SRC) M=$(RT28xx_DIR)/os/linux modules
 
 osutil:
 ifeq ($(OSABL),YES)
 	cp os/linux/Makefile.6.util $(RT28xx_DIR)/os/linux/Makefile
-	$(MAKE) -C $(LINUX_SRC) SUBDIRS=$(RT28xx_DIR)/os/linux modules
+	$(MAKE) -C $(LINUX_SRC) M=$(RT28xx_DIR)/os/linux modules
 endif
 
 osnet:
 ifeq ($(OSABL),YES)
 	cp os/linux/Makefile.6.netif $(RT28xx_DIR)/os/linux/Makefile
-	$(MAKE) -C $(LINUX_SRC) SUBDIRS=$(RT28xx_DIR)/os/linux modules
+	$(MAKE) -C $(LINUX_SRC) M=$(RT28xx_DIR)/os/linux modules
 endif
 
 osdrv:
 	cp os/linux/Makefile.6 $(RT28xx_DIR)/os/linux/Makefile
-	$(MAKE) -C $(LINUX_SRC) SUBDIRS=$(RT28xx_DIR)/os/linux modules
+	$(MAKE) -C $(LINUX_SRC) M=$(RT28xx_DIR)/os/linux modules
 
 # Declare the contents of the .PHONY variable as phony. We keep that information in a variable
 .PHONY: $(PHONY)

--- a/include/os/rt_linux.h
+++ b/include/os/rt_linux.h
@@ -148,8 +148,6 @@ extern	const struct iw_handler_def rt28xx_ap_iw_handler_def;
 /***********************************************************************************
  *	Compiler related definitions
  ***********************************************************************************/
-#undef __inline
-#define __inline		static inline
 #define IN
 #define OUT
 #define INOUT

--- a/include/rt_os_net.h
+++ b/include/rt_os_net.h
@@ -259,7 +259,7 @@ PNET_DEV RtmpPhyNetDevMainCreate(VOID *pAd);
 int rt28xx_close(VOID *dev);
 int rt28xx_open(VOID *dev);
 
-__inline INT VIRTUAL_IF_UP(VOID *pAd)
+static inline INT VIRTUAL_IF_UP(VOID *pAd)
 {
 	RT_CMD_INF_UP_DOWN InfConf = { rt28xx_open, rt28xx_close };
 	if (RTMP_COM_IoctlHandle(pAd, NULL, CMD_RTPRIV_IOCTL_VIRTUAL_INF_UP,
@@ -268,7 +268,7 @@ __inline INT VIRTUAL_IF_UP(VOID *pAd)
 	return 0;
 }
 
-__inline VOID VIRTUAL_IF_DOWN(VOID *pAd)
+static inline VOID VIRTUAL_IF_DOWN(VOID *pAd)
 {
 	RT_CMD_INF_UP_DOWN InfConf = { rt28xx_open, rt28xx_close };
 	RTMP_COM_IoctlHandle(pAd, NULL, CMD_RTPRIV_IOCTL_VIRTUAL_INF_DOWN,


### PR DESCRIPTION
`make SUBDIRS=...` was removed from kernel recently.
`M=` argument is known at least in linux-2.6, so there is no need to add any code for compatibility.

I already use this module with linux-5.6.7 on x86_64 and ARM without errors for 24+ hours.