### PR TITLE
Fix building on kernel >= 6.12

### DIFF
--- a/include/os/rt_linux.h
+++ b/include/os/rt_linux.h
@@ -52,7 +52,11 @@
 #include <linux/unistd.h>
 #include <asm/uaccess.h>
 #include <asm/types.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 #include <asm/unaligned.h>	/* for get_unaligned() */
+#else
+#include <linux/unaligned.h>
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27)
 #include <linux/pid.h>


### PR DESCRIPTION
`asm/unaligned.h` has been renamed to `linux/unaligned.h` in kernel 6.12 (debian's default)

I was able to build, haven't tested if it works yet